### PR TITLE
Use installation parameters as well as regular ones.

### DIFF
--- a/src/app/services/brand-color.service.ts
+++ b/src/app/services/brand-color.service.ts
@@ -32,7 +32,7 @@ export class BrandColorService {
 
       this.activeColor = await sdk.field.getValue();
       this.selected = (this.activeColor == null) ? null : { name: this.activeColor, color: this.activeColor };
-      this.params = sdk.params.instance as BrandColorParameters;
+      this.params = { ...sdk.params.installation, ...sdk.params.instance } as BrandColorParameters;
 
       const client = new ContentClient({
         account: this.params.account || 'dummy',


### PR DESCRIPTION
This PR allows the brand colours extension to load parameters from the installation params. When there is a conflict, the instance parameters will be preferred.